### PR TITLE
test(docker): verify application-only change workflow efficiency

### DIFF
--- a/packages/tdr-bot/src/main.ts
+++ b/packages/tdr-bot/src/main.ts
@@ -28,6 +28,7 @@ async function main() {
   dotenv.config()
   sourceMapSupport.install()
 
+  // Test application-only change for Docker build workflow
   if (env<EnvKey>('GRAPH_TEST', 'false') === 'true') {
     await runGraphTest()
   } else {

--- a/scripts/detect-docker-changes.sh
+++ b/scripts/detect-docker-changes.sh
@@ -24,7 +24,7 @@ error() {
 get_changed_files() {
     if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
         # For PRs, compare against base branch
-        git diff --name-only "$GITHUB_BASE_REF"..HEAD
+        git diff --name-only "origin/$GITHUB_BASE_REF"..HEAD
     else
         # For pushes to main, compare against previous commit
         git diff --name-only HEAD~1..HEAD


### PR DESCRIPTION
## Summary
- Test the Docker build workflow with a true application-only change scenario
- Added a comment to `packages/tdr-bot/src/main.ts` to simulate application code change
- Fixed the detect-docker-changes script to properly handle PR git diff references

## Expected behavior
- [x] Only tdr-bot changes should be detected
- [ ] Base images should NOT be built (skipped)
- [ ] Only tdr-bot application image should be built
- [ ] Workflow should complete successfully with optimal build time

This test verifies the workflow correctly skips unnecessary base image builds when only application code changes.

🤖 Generated with [Claude Code](https://claude.ai/code)